### PR TITLE
If possible to stringify synchronously, do so. Prevents a RangeError due...

### DIFF
--- a/lib/async-json.js
+++ b/lib/async-json.js
@@ -1,6 +1,6 @@
 (function (exports, undefined) {
     "use strict";
-    
+
     if (!JSON || !JSON.stringify) {
         // older browsers
         throw new Error("The json2.js file must be included before async-json.js");
@@ -12,12 +12,12 @@
     };
     var getKeys = Object.keys || (function () {
         // older browsers
-        
+
         var has = Object.prototype.hasOwnProperty || function () {
             // Object.prototype.hasOwnProperty should really always exist.
             return true;
         };
-        
+
         return function (obj) {
             var result = [];
             for (var key in obj) {
@@ -30,7 +30,7 @@
     }());
 
     var stringify;
-    
+
     /**
      * Stringify an array
      *
@@ -46,44 +46,61 @@
             callback(null, "[]");
             return;
         }
-        
+
         // buffer is our ultimate return value
         var buffer = "[";
-        
+
         var handle = function (n) {
             if (n === len) {
                 // we're done
                 buffer += "]";
                 callback(null, buffer);
-                return;
+                return false;
             }
-            
+
+            var synchronous = true;
+            var completedSynchronously = false;
             // asynchronously stringify the nth element.
             stringify(array[n], function (err, value) {
                 if (err) {
                     callback(err);
                     return;
                 }
- 
+
                 if (n > 0) {
                     buffer += ",";
                 }
-                
+
                 if (value === undefined) {
                     // JSON.stringify turns bad values in arrays into null, so we need to as well
                     buffer += "null";
                 } else {
                     buffer += value;
                 }
-                
+
                 // go to the next element
-                handle(n + 1);
+                if (synchronous) {
+                  completedSynchronously = true;
+                } else {
+                  run(n + 1);
+                }
             }, String(n));
+            synchronous = false;
+            return completedSynchronously;
         };
+
+        var run = function (start) {
+          for (var i = start;; ++i) {
+            if (!handle(i)) {
+              break;
+            }
+          }
+        };
+
         // let's pump, starting at index 0
-        handle(0);
+        run(0);
     };
-    
+
     /**
      * Stringify an object
      *
@@ -102,21 +119,23 @@
             callback(null, "{}");
             return;
         }
-        
+
         // whether or not we've placed the first element in yet.
         // can't rely on i === 0, since we might skip it if the value === undefined.
         var first = true;
-        
+
         // buffer is our ultimate return value
         var buffer = "{";
-        
+
         var handle = function (n) {
             if (n === len) {
                 buffer += "}";
                 callback(null, buffer);
-                return;
+                return false;
             }
-            
+
+            var synchronous = true;
+            var completedSynchronously = false;
             var key = keys[n];
             // asynchronously stringify the nth element in our list of keys
             stringify(object[key], function (err, value) {
@@ -124,7 +143,7 @@
                     callback(err);
                     return;
                 }
-                
+
                 // if we get an undefined, rather than placing in null like the array does, we just skip it.
                 if (value !== undefined) {
                     if (first) {
@@ -132,26 +151,41 @@
                     } else {
                         buffer += ",";
                     }
-                    
+
                     buffer += jsonStringify(key);
                     buffer += ":";
                     buffer += value;
                 }
-                
+
                 // go to the next key
-                handle(n + 1);
+                if (synchronous) {
+                  completedSynchronously = true;
+                } else {
+                  run(n + 1);
+                }
             }, key);
+            synchronous = false;
+            return completedSynchronously;
         };
+
+        var run = function (start) {
+          for (var i = start;; ++i) {
+            if (!handle(i)) {
+              break;
+            }
+          }
+        };
+
         // let's pump, starting at index 0
-        handle(0);
+        run(0);
     };
-    
+
     /**
      * Asynchronously convert a JavaScript object to JSON.
      * If any functions are supplied in the data, it will be invoked.
      * If the function has 0 parameters, it will be invoked and treated as synchronous, its return value being its replacement.
      * Otherwise, the first parameter is assumed to be a callback which should be invoked as callback(error, result)
-     * 
+     *
      * @param {Any} data Any JavaScript object.
      * @param {Function} callback A callback that takes an error and the result as parameters.
      * @api public


### PR DESCRIPTION
... to stack size. Closes #2